### PR TITLE
Added options for ignoredCollections

### DIFF
--- a/cmd/provendb-verify/cli.go
+++ b/cmd/provendb-verify/cli.go
@@ -18,8 +18,8 @@
  *
  * @Author: guiguan
  * @Date:   2019-04-02T13:35:55+11:00
- * @Last modified by:   guiguan
- * @Last modified time: 2019-12-19T22:08:55+11:00
+ * @Last modified by:   Michael Harrison
+ * @Last modified time: 2020-01-15T09:30:49+11:00
  */
 
 package main
@@ -44,6 +44,10 @@ import (
 
 type outOpt struct {
 	path string
+}
+
+type ignoredCollectionsOpt struct {
+	ignoredCollections []string
 }
 
 type docOpt struct {
@@ -250,6 +254,13 @@ func handleCLI(c *cli.Context) int {
 
 			opts = append(opts, outOpt{
 				out,
+			})
+		}
+
+		if ignoredCollections := c.String("ignoredCollections"); ignoredCollections != "" {
+
+			opts = append(opts, ignoredCollectionsOpt{
+				ignoredCollections: strings.Split(ignoredCollections, ","),
 			})
 		}
 

--- a/cmd/provendb-verify/cli.go
+++ b/cmd/provendb-verify/cli.go
@@ -19,7 +19,7 @@
  * @Author: guiguan
  * @Date:   2019-04-02T13:35:55+11:00
  * @Last modified by:   Michael Harrison
- * @Last modified time: 2020-01-15T09:30:49+11:00
+ * @Last modified time: 2020-01-17T12:01:33+11:00
  */
 
 package main
@@ -257,10 +257,10 @@ func handleCLI(c *cli.Context) int {
 			})
 		}
 
-		if ignoredCollections := c.String("ignoredCollections"); ignoredCollections != "" {
+		if ignoredCollections := c.StringSlice("ignoredCollections"); ignoredCollections != nil {
 
 			opts = append(opts, ignoredCollectionsOpt{
-				ignoredCollections: strings.Split(ignoredCollections, ","),
+				ignoredCollections,
 			})
 		}
 

--- a/cmd/provendb-verify/hash.go
+++ b/cmd/provendb-verify/hash.go
@@ -18,8 +18,8 @@
  *
  * @Author: guiguan
  * @Date:   2019-04-02T13:42:23+11:00
- * @Last modified by:   guiguan
- * @Last modified time: 2019-12-19T20:27:45+11:00
+ * @Last modified by:   Michael Harrison
+ * @Last modified time: 2020-01-15T09:41:19+11:00
  */
 
 package main
@@ -57,6 +57,7 @@ func hashDatabase(
 	version int64,
 	proofMap map[string]map[string]*merkle.Proof,
 	cols []string,
+	ignoredCollections []string,
 ) (result hashResult, err error) {
 	select {
 	case <-ctx.Done():
@@ -67,9 +68,14 @@ func hashDatabase(
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
+	ignoredCollectionsRegex := ""
+	for _, collection := range ignoredCollections {
+		ignoredCollectionsRegex += "^" + collection + "$|"
+	}
+
 	colNameFilter := bsonx.Doc{
 		{"$not", bsonx.Regex(
-			"^"+provenDBMetaPrefix+"|^"+mongoDBSystemPrefix+"|"+provenDBIgnoredSuffix+"$",
+			"^"+provenDBMetaPrefix+"|^"+mongoDBSystemPrefix+"|"+ignoredCollectionsRegex+provenDBIgnoredSuffix+"$",
 			"",
 		)},
 	}

--- a/cmd/provendb-verify/provendb-verify.go
+++ b/cmd/provendb-verify/provendb-verify.go
@@ -158,7 +158,7 @@ COPYRIGHT:
 			},
 			&cli.StringSliceFlag{
 				Name:        "ignoredCollections",
-				Usage:       wrap("Ignore a comma seperated list of values when verifying proofs."),
+				Usage:       wrap("specify a comma seperated list of ignored collections"),
 				DefaultText: "",
 			},
 			&cli.StringFlag{

--- a/cmd/provendb-verify/provendb-verify.go
+++ b/cmd/provendb-verify/provendb-verify.go
@@ -19,7 +19,7 @@
  * @Author: guiguan
  * @Date:   2018-08-01T13:23:16+10:00
  * @Last modified by:   Michael Harrison
- * @Last modified time: 2020-01-15T09:22:32+11:00
+ * @Last modified time: 2020-01-17T12:00:59+11:00
  */
 
 package main
@@ -156,7 +156,7 @@ COPYRIGHT:
 				Aliases: []string{"p"},
 				Usage:   wrap("specify a `PASSWORD` for the MongoDB authentication"),
 			},
-			&cli.BoolFlag{
+			&cli.StringSliceFlag{
 				Name:        "ignoredCollections",
 				Usage:       wrap("Ignore a comma seperated list of values when verifying proofs."),
 				DefaultText: "",

--- a/cmd/provendb-verify/provendb-verify.go
+++ b/cmd/provendb-verify/provendb-verify.go
@@ -18,8 +18,8 @@
  *
  * @Author: guiguan
  * @Date:   2018-08-01T13:23:16+10:00
- * @Last modified by:   guiguan
- * @Last modified time: 2019-12-19T18:44:30+11:00
+ * @Last modified by:   Michael Harrison
+ * @Last modified time: 2020-01-15T09:22:32+11:00
  */
 
 package main
@@ -156,6 +156,11 @@ COPYRIGHT:
 				Aliases: []string{"p"},
 				Usage:   wrap("specify a `PASSWORD` for the MongoDB authentication"),
 			},
+			&cli.BoolFlag{
+				Name:        "ignoredCollections",
+				Usage:       wrap("Ignore a comma seperated list of values when verifying proofs."),
+				DefaultText: "",
+			},
 			&cli.StringFlag{
 				Name:    "authDatabase",
 				Aliases: []string{"adb"},
@@ -183,7 +188,7 @@ COPYRIGHT:
 				Usage:   wrap("specify a `PATH` to a ProvenDB Proof Archive (.zip) or an external Chainpoint Proof either in base64 (.txt) or JSON (.json). The (.txt) or (.json) will be used to verify the database or document, instead of using the stored one in ProvenDB. If the database or document is not specified, the (.txt) or (.json) itself will only be verified. You can use '--out' to output such (.txt) or (.json)"),
 			},
 			&cli.StringFlag{
-				Name:	"pubKey",
+				Name:  "pubKey",
 				Usage: wrap("specify a `PATH` to a RSA public key (.pem) to verify the signature contained in a Proof"),
 			},
 			&cli.BoolFlag{

--- a/cmd/provendb-verify/verify.go
+++ b/cmd/provendb-verify/verify.go
@@ -18,8 +18,8 @@
  *
  * @Author: guiguan
  * @Date:   2019-04-02T13:37:34+11:00
- * @Last modified by:   guiguan
- * @Last modified time: 2019-12-19T22:32:03+11:00
+ * @Last modified by:   Michael Harrison
+ * @Last modified time: 2020-01-15T09:40:28+11:00
  */
 
 package main
@@ -192,6 +192,7 @@ func verifyProof(
 		proofName, outPath        string
 		proofDocOpt               *docOpt
 		pubKey                    *rsa.PublicKey
+		ignoredCollections        []string
 	)
 
 	if database != nil {
@@ -213,6 +214,8 @@ func verifyProof(
 			}
 		case pubKeyOpt:
 			pubKey = o
+		case ignoredCollectionsOpt:
+			ignoredCollections = o.ignoredCollections
 		}
 	}
 
@@ -318,7 +321,7 @@ func verifyProof(
 		}
 
 		if actualHash == nil {
-			hr, err = hashDatabase(ctx, database, version, proofMap, cols)
+			hr, err = hashDatabase(ctx, database, version, proofMap, cols, ignoredCollections)
 			if err != nil {
 				return
 			}


### PR DESCRIPTION
Added an option to the verify tool to ignore certain collections.
The option is a comma-separated string.